### PR TITLE
feat: 🎸 Initialize domain ID during extension setup

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -113,9 +113,7 @@
 		"RevisionRecordInserted": "handleHashWriterHooks",
 		"ArticleDeleteComplete": "handleHashWriterHooks",
 		"PageMoveComplete": "handleHashWriterHooks",
-		"LoadExtensionSchemaUpdates": {
-			"handler": "handleHashWriterHooks"
-		},
+		"LoadExtensionSchemaUpdates": "DataAccounting\\Hooks::onLoadExtensionSchemaUpdates",
 		"XmlDumpWriterOpenPage": "DataAccounting\\Hooks::onXmlDumpWriterOpenPage",
 		"XmlDumpWriterWriteRevision": "DataAccounting\\Hooks::onXmlDumpWriterWriteRevision",
 		"ImportHandlePageXMLTag": "DataAccounting\\Hooks::onImportHandlePageXMLTag"

--- a/includes/HashWriterHooks.php
+++ b/includes/HashWriterHooks.php
@@ -9,7 +9,6 @@ namespace DataAccounting;
 
 use DatabaseUpdater;
 use MediaWiki\Hook\PageMoveCompleteHook;
-use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\Hook\ArticleDeleteCompleteHook;
 use MediaWiki\Page\Hook\RevisionFromEditCompleteHook;
@@ -26,8 +25,7 @@ class HashWriterHooks implements
 	RevisionFromEditCompleteHook,
 	RevisionRecordInsertedHook,
 	ArticleDeleteCompleteHook,
-	PageMoveCompleteHook,
-	LoadExtensionSchemaUpdatesHook
+	PageMoveCompleteHook
 {
 
 	// This function updates the dataset wit the correct revision ID, especially important during import.
@@ -95,16 +93,5 @@ class HashWriterHooks implements
 				'page_id' => $pageid ],
 			__METHOD__
 		);
-	}
-
-	/**
-	 * Register our database schema.
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/LoadExtensionSchemaUpdates
-	 *
-	 * @param DatabaseUpdater $updater
-	 */
-	public function onLoadExtensionSchemaUpdates( $updater ) {
-		$updater->addExtensionTable( 'data_accounting', dirname( __DIR__ ) . '/sql/data_accounting.sql' );
 	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -12,6 +12,7 @@ use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\Hook\OutputPageParserOutputHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\SkinTemplateNavigationHook;
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Revision\RevisionRecord;
@@ -26,14 +27,17 @@ use SkinTemplate;
 use stdClass;
 use Title;
 use XMLReader;
+use DatabaseUpdater;
 
 require_once 'ApiUtil.php';
+require_once 'Util.php';
 
 class Hooks implements
 	BeforePageDisplayHook,
 	ParserFirstCallInitHook,
 	SkinTemplateNavigationHook,
-	OutputPageParserOutputHook
+	OutputPageParserOutputHook,
+	LoadExtensionSchemaUpdatesHook
 {
 
 	private PermissionManager $permissionManager;
@@ -219,5 +223,17 @@ class Hooks implements
 
 		// This prevents continuing down the else-if statements in WikiImporter, which would reach `$tag != '#text'`
 		return false;
+	}
+
+	/**
+	 * - Register our database schema.
+	 * - Initialize domain ID.
+	 *
+	 * @param DatabaseUpdater $updater DatabaseUpdater subclass
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/LoadExtensionSchemaUpdates
+	 */
+	public function onLoadExtensionSchemaUpdates( $updater ) {
+		$updater->addExtensionTable( 'data_accounting', dirname( __DIR__ ) . '/sql/data_accounting.sql' );
+		maybeGenerateDomainId();
 	}
 }

--- a/includes/Util.php
+++ b/includes/Util.php
@@ -26,15 +26,18 @@ function generateDomainId(): string {
 	return substr( $domain_id_full, 0, 10 );
 }
 
-function getDomainId(): string {
+function getDomainID(): string {
+	return MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'da' )
+		->get( 'DomainID' );
+}
+
+function maybeGenerateDomainId(): void {
 	$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'da' );
 	$domainID = (string)$config->get( 'DomainID' );
 	if ( $domainID === "UnspecifiedDomainId" ) {
 		// A default domain ID is still used, so we generate a new one
-		$domainID = generateDomainId();
-		$config->set( 'DomainID', $domainID );
+		$config->set( 'DomainID', generateDomainId() );
 	}
-	return $domainID;
 }
 
 function editPageContent( WikiPage $page, string $text, string $comment, User $user ): void {


### PR DESCRIPTION
This supersedes #156. However, upon testing, I got this error
```
ConfigException from line 137 of /var/www/html/includes/config/ConfigFactory.php: No registered builder available for da.
#0 /var/www/html/extensions/DataAccounting/includes/Util.php(35): ConfigFactory->makeConfig('da')
#1 /var/www/html/extensions/DataAccounting/includes/Hooks.php(237): maybeGenerateDomainId()
#2 /var/www/html/includes/HookContainer/HookContainer.php(338): DataAccounting\Hooks::onLoadExtensionSchemaUpdates(Object(MysqlUpdater))
#3 /var/www/html/includes/HookContainer/HookContainer.php(137): MediaWiki\HookContainer\HookContainer->callLegacyHook('LoadExtensionSc...', Array, Array, Array)
#4 /var/www/html/includes/HookContainer/HookRunner.php(2350): MediaWiki\HookContainer\HookContainer->run('LoadExtensionSc...', Array, Array)
#5 /var/www/html/includes/installer/DatabaseUpdater.php(142): MediaWiki\HookContainer\HookRunner->onLoadExtensionSchemaUpdates(Object(MysqlUpdater))
#6 /var/www/html/includes/installer/DatabaseUpdater.php(500): DatabaseUpdater->loadExtensionSchemaUpdates()
#7 /var/www/html/includes/installer/DatabaseInstaller.php(348): DatabaseUpdater->doUpdates(Array)
#8 /var/www/html/includes/installer/Installer.php(1714): DatabaseInstaller->createExtensionTables(Object(MysqlInstaller))
#9 /var/www/html/includes/installer/CliInstaller.php(211): Installer->performInstallation(Array, Array)
#10 /var/www/html/maintenance/install.php(142): CliInstaller->execute()
#11 /var/www/html/maintenance/doMaintenance.php(108): CommandLineInstaller->execute()
#12 /var/www/html/maintenance/install.php(203): require_once('/var/www/html/m...')
#13 {main}
```
Looks like the service wiring is initialized after the `LoadExtensionSchemaUpdates` hook?