### PR TITLE
Temporarily disable uploads in wikieditor

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -298,6 +298,11 @@
 			"scripts": [
 				"ext.dataAccounting.updateTransclusionHashes.js"
 			]
+		},
+		"ext.dataaccounting.disableeditorupload": {
+			"scripts": [
+				"disableEditoruploads.js"
+			]
 		}
 	},
 	"ServiceWiringFiles": [

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -80,6 +80,11 @@ class Hooks implements
 			$out->addModules( 'ext.DataAccounting.signMessage' );
 			$out->addModules( 'publishDomainManifest' );
 		}
+		if ( $out->getTitle()->getNamespace() > -1
+			// temporarily disable uploads in wikieditor. VERY HACKY!
+			&& $out->getRequest()->getVal( 'action' ) === 'edit' ) {
+			$out->addModules( 'ext.dataaccounting.disableeditorupload' );
+		}
 	}
 
 	public function onOutputPageParserOutput( $out, $parserOutput ): void {

--- a/modules/disableEditoruploads.js
+++ b/modules/disableEditoruploads.js
@@ -1,0 +1,3 @@
+( function( mw ) {
+	mw.config.values.wgEnableUploads = false;
+} )( mediaWiki );


### PR DESCRIPTION
Note that this is very hacky, but is necessary due to no ability to override the global wgEnableUploads based on context, as this config is not loaded within the main request. The WikiEditor extension is checking this value, but just shows a basic "Uploads are disabled" message, which is also very ugly