### PR TITLE
feat: Always write canonical titles to DB

### DIFF
--- a/includes/API/GetHashChainInfoHandler.php
+++ b/includes/API/GetHashChainInfoHandler.php
@@ -59,15 +59,13 @@ class GetHashChainInfoHandler extends AuthorizedEntityHandler {
 	 */
 	protected function getEntity( string $identifierType ): ?VerificationEntity {
 		$identifier = $this->getValidatedParams()['identifier'];
-		$conds = [];
 		if ( $identifierType === 'title' ) {
-			// TODO: DB data should hold Db key, not prefixed text (spaces replaced with _)
-			// Once that is done, remove next line
-			$identifier = str_replace( '_', ' ', $identifier );
-			$conds['page_title'] = $identifier;
+			$title = \Title::newFromText( $identifier );
+			return $this->verificationEngine->getLookup()->verificationEntityFromTitle( $title );
 		} else {
-			$conds[VerificationEntity::GENESIS_HASH] = $identifier;
+			return $this->verificationEngine->getLookup()->verificationEntityFromQuery( [
+				VerificationEntity::GENESIS_HASH => $identifier,
+			] );
 		}
-		return $this->verificationEngine->getLookup()->verificationEntityFromQuery( $conds );
 	}
 }

--- a/includes/API/GetPageAllRevsHandler.php
+++ b/includes/API/GetPageAllRevsHandler.php
@@ -38,11 +38,7 @@ class GetPageAllRevsHandler extends AuthorizedEntityHandler {
 	 * @return VerificationEntity|null
 	 */
 	protected function getEntity( string $pageTitle ): ?VerificationEntity {
-		// TODO: DB data should hold Db key, not prefixed text (spaces replaced with _)
-		// Once that is done, remove next line
-		$pageTitle = str_replace( '_', ' ', $pageTitle );
-		return $this->verificationEngine->getLookup()->verificationEntityFromQuery( [
-			'page_title' => $pageTitle
-		] );
+		$title = \Title::newFromText( $pageTitle );
+		return $this->verificationEngine->getLookup()->verificationEntityFromTitle( $title );
 	}
 }

--- a/includes/API/GetPageLastRevHandler.php
+++ b/includes/API/GetPageLastRevHandler.php
@@ -35,12 +35,7 @@ class GetPageLastRevHandler extends AuthorizedEntityHandler {
 	 * @return VerificationEntity|null
 	 */
 	protected function getEntity(): ?VerificationEntity {
-		$pageTitle = $this->getValidatedParams()['page_title'];
-		// TODO: DB data should hold Db key, not prefixed text (spaces replaced with _)
-		// Once that is done, remove next line
-		$pageTitle = str_replace( '_', ' ', $pageTitle );
-		return $this->verificationEngine->getLookup()->verificationEntityFromQuery( [
-			'page_title' => $pageTitle
-		] );
+		$title = \Title::newFromText( $this->getValidatedParams()['page_title'] );
+		return $this->verificationEngine->getLookup()->verificationEntityFromTitle( $title );
 	}
 }

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -40,7 +40,10 @@ return [
 	},
 	'DataAccountingVerificationEngine' => static function( MediaWikiServices $services ): VerificationEngine {
 		$entityFactory = new VerificationEntityFactory( $services->getTitleFactory(), $services->getRevisionStore() );
-		$lookup = new VerificationLookup( $services->getDBLoadBalancer(), $services->getRevisionStore(), $entityFactory );
+		$lookup = new VerificationLookup(
+			$services->getDBLoadBalancer(), $services->getRevisionStore(),
+			$entityFactory, $services->getNamespaceInfo()
+		);
 		$config = $services->getConfigFactory()->makeConfig( 'da' );
 
 		return new VerificationEngine(

--- a/includes/Transfer/Exporter.php
+++ b/includes/Transfer/Exporter.php
@@ -38,6 +38,9 @@ class Exporter {
 
 		foreach ( $map as $dbKey => $data ) {
 			$context = $this->transferEntityFactory->newTransferContextFromTitle( $data['title'] );
+			if ( !$context ) {
+				continue;
+			}
 			$pageData = $context->jsonSerialize();
 			// TODO: Remove site info from context
 			unset( $pageData['site_info'] );

--- a/includes/Verification/VerificationLookup.php
+++ b/includes/Verification/VerificationLookup.php
@@ -62,7 +62,7 @@ class VerificationLookup {
 	 * @return VerificationEntity|null
 	 */
 	public function verificationEntityFromTitle( Title $title ): ?VerificationEntity {
-		if ( !$title->exists() ) {
+		if ( !( $title instanceof Title ) || !$title->exists() ) {
 			return null;
 		}
 		// TODO: Replace with getPrefixedDBkey, once database enties use it


### PR DESCRIPTION
If PKC is in german, page Vorlage:Test will be written to `revision_verification`
as Template:Test. This helps with identifying pages in case of language change
during the lifetime of PKC

close #330