### PR TITLE
Create docker img

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -1,0 +1,42 @@
+name: "Bild and Push Docker-Image"
+
+on:
+  push:
+
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and Push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Log into GH container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: actionfiles/build_and_push_docker_image/Dockerfile

--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    name: Build and Push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    name: Build and Push
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/actionfiles/build_and_push_docker_image/Dockerfile
+++ b/actionfiles/build_and_push_docker_image/Dockerfile
@@ -1,0 +1,4 @@
+FROM inblockio/micro-pkc-mediawiki:1.0.0-alpha.4
+WORKDIR /var/www/html
+RUN mkdir ./extensions/DataAccounting
+COPY . ./extensions/DataAccounting/


### PR DESCRIPTION
I have made the following changes:

A Docker image is now automatically pushed to the Github Registry, which is based on the MediaWiki image. This image is tagged with the branch on which the commit was pushed (e.g., FeatureXY-Branch -> ghcr.io/inblockio/mediawiki-extensions-aqua:FeatureXY-Branch). The workflow is triggered with every push to this repository.