### PR TITLE
Add API endpoint to get recent changes

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -55,7 +55,7 @@ paths:
   /data_accounting/get_page_all_revs/{page_or_hash}:
     get:
       tags:
-          - general
+        - general
       summary: Get all revisions for a page
       parameters:
         - name: page_or_hash
@@ -84,15 +84,42 @@ paths:
                     example: [ 1, 2, 3 ]
                   - type: array
                     items:
-                        $ref: '#/components/schemas/VerificationEntity'
+                      $ref: '#/components/schemas/VerificationEntity'
         '401':
           description: Permission error
         '404':
           description: Invalid ID supplied
+  /data_accounting/recent_changes:
+    get:
+      tags:
+        - general
+      summary: "Get recent changes in PKC"
+      parameters:
+        - name: count
+          in: query
+          description: Number of latest changes to retrive
+          required: false
+          schema:
+            type: integer
+        - name: since
+          in: query
+          description: Timestamp, return changes newer that this, in format YmdHis (20240101090000)
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecentChange'
   /data_accounting/get_branch/{revision_hash}:
     get:
       tags:
-          - general
+        - general
       summary: Get all revisions for branch
       parameters:
         - name: revision_hash
@@ -131,13 +158,13 @@ paths:
         - general
       summary: Get ID and verification has of the last revision of the page
       parameters:
-          - name: page_title
-            in: query
-            description: Title of the page for which to return the last revision
-            required: true
-            example: 'Main_Page'
-            schema:
-                type: string
+        - name: page_title
+          in: query
+          description: Title of the page for which to return the last revision
+          required: true
+          example: 'Main_Page'
+          schema:
+            type: string
       responses:
         '200':
           description: successful operation
@@ -195,8 +222,8 @@ paths:
           description: Depth of the Merkle proof
           required: false
           schema:
-              type: integer
-              format: int64
+            type: integer
+            format: int64
       responses:
         '200':
           description: successful operation
@@ -362,14 +389,14 @@ paths:
                   type: integer
                   example: 1
                 account_address:
-                    type: string
-                    example: '0xabc...cba'
+                  type: string
+                  example: '0xabc...cba'
                 transaction_hash:
-                    type: string
-                    example: 'abc...cba'
+                  type: string
+                  example: 'abc...cba'
                 witness_network:
-                    type: string
-                    example: 'goerli'
+                  type: string
+                  example: 'goerli'
       responses:
         '200':
           description: successful operation
@@ -378,7 +405,7 @@ paths:
         '404':
           description: Invalid input data
         '500':
-            description: Internal server error
+          description: Internal server error
   /data_accounting/transclusion/update_hash:
     post:
       tags:
@@ -412,7 +439,7 @@ paths:
         '404':
           description: Invalid input data
         '500':
-            description: Internal server error
+          description: Internal server error
   /data_accounting/delete_revisions:
     post:
       tags:
@@ -447,7 +474,7 @@ paths:
         '404':
           description: Invalid input data
         '500':
-            description: Internal server error
+          description: Internal server error
   /data_accounting/squash_revisions:
     post:
       tags:
@@ -482,7 +509,7 @@ paths:
         '404':
           description: Invalid input data
         '500':
-            description: Internal server error
+          description: Internal server error
   /data_accounting/import:
     post:
       tags:
@@ -497,12 +524,12 @@ paths:
                 context:
                   type: object
                   properties:
-                      namespace:
-                        type: integer
-                        example: 0
-                      title:
-                        type: string
-                        example: 'Main_Page'
+                    namespace:
+                      type: integer
+                      example: 0
+                    title:
+                      type: string
+                      example: 'Main_Page'
                 revision:
                   $ref: '#/components/schemas/ExportImportEntity'
       responses:
@@ -521,7 +548,7 @@ paths:
         '404':
           description: Invalid input data
         '500':
-            description: Internal server error
+          description: Internal server error
 components:
   schemas:
     ServerInfo:
@@ -541,15 +568,15 @@ components:
           format: int64
           example: 1
         rev_id:
-            type: integer
-            format: int64
-            example: 1
+          type: integer
+          format: int64
+          example: 1
         domain_id:
-            type: string
-            example: 'abc123'
+          type: string
+          example: 'abc123'
         time_stamp:
-            type: string
-            example: '20240508072948'
+          type: string
+          example: '20240508072948'
         verification_context:
           type: object
           properties:
@@ -560,40 +587,40 @@ components:
               type: boolean
               example: true
         signature:
-            type: string
-            nullable: true
-            example: 'abc123'
+          type: string
+          nullable: true
+          example: 'abc123'
         public_key:
-            type: string
-            example: 'abc123'
+          type: string
+          example: 'abc123'
         wallet_address:
-            type: string
-            example: 'abc123'
+          type: string
+          example: 'abc123'
         witness_event_id:
-            type: string
-            nullable: true
-            example: 'abc123'
+          type: string
+          nullable: true
+          example: 'abc123'
         source:
-            type: string
-            example: 'default'
+          type: string
+          example: 'default'
         verification_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
         content_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
         genesis_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
         metadata_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
         signature_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
         previous_verification_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
     LastRevision:
       type: object
       properties:
@@ -605,216 +632,231 @@ components:
           format: int64
           example: 1
         rev_id:
-            type: integer
-            format: int64
-            example: 1
+          type: integer
+          format: int64
+          example: 1
         verification_hash:
-            type: string
-            example: 'abc....cba'
+          type: string
+          example: 'abc....cba'
     WitnessEntity:
-        type: object
-        properties:
-            witness_event_id:
-              type: integer
-              example: 1
+      type: object
+      properties:
+        witness_event_id:
+          type: integer
+          example: 1
+        domain_id:
+          type: string
+          example: 'abc123'
+        domain_snapshot_title:
+          type: string
+          example: 'Data Accounting:DomainSnapshot 1'
+        witness_hash:
+          type: string
+          nullable: true
+          example: 'abc123'
+        domain_snapshot_genesis_hash:
+          type: string
+          example: 'abc....cba'
+        merkle_root:
+          type: string
+          example: 'abc....cba'
+        witness_event_verification_hash:
+          type: string
+          example: 'abc....cba'
+        witness_network:
+          type: string
+          example: 'goerli'
+        smart_contract_address:
+          type: string
+          example: '0xabc123'
+        witness_event_transaction_hash:
+          type: string
+          example: 'ABC'
+        sender_account_address:
+          type: string
+          example: 'ABC'
+        source:
+          type: string
+          nullable: true
+          example: 'abc'
+    ProofNode:
+      type: object
+      properties:
+        witness_event_verification_hash:
+          type: string
+          example: 'abc...cba'
+        depth:
+          type: integer
+          format: int64
+          example: 1
+        left_leaf:
+          type: string
+          example: 'abc...cba'
+        right_leaf:
+          type: string
+          example: 'abc...cba'
+        successor:
+          type: string
+          example: 'abc...cba'
+        id:
+          type: integer
+          format: int64
+          example: 1
+        witness_event_id:
+          type: integer
+          example: 1
+    ExportImportEntity:
+      type: object
+      properties:
+        verification_context:
+          type: object
+          properties:
+            has_previous_signature:
+              type: boolean
+              example: true
+            has_previous_witness:
+              type: boolean
+              example: true
+        content:
+          type: object
+          properties:
+            content:
+              type: object
+              properties:
+                content:
+                  type: object
+                  properties:
+                    main:
+                      type: string
+                      description: Main content of the revision, text of the page
+                      example: 'Hello, world!'
+                    signature-slot:
+                      type: string
+                      description: JSON string of an array of signatures
+                      example: "[{\"signature\": \"0x..,\", \"timestamp\": \"20240101101010\"}...]"
+                    transclusion-hashes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          dbkey:
+                            type: string
+                            example: 'MyPage'
+                          ns:
+                            type: integer
+                            example: 10
+                          verification_hash:
+                            type: string
+                            example: 'abc...cba'
+                file:
+                  type: object
+                  properties:
+                    data:
+                      type: string
+                      description: Base64 encoded file data
+                      example: 'd3an...asd'
+                    filename:
+                      type: string
+                      example: 'MyFile.png'
+                    size:
+                      type: integer
+                      description: Size of the file in bytes
+                      example: 12345
+                    comment:
+                      type: string
+                      description: Comment added when uploading file
+                      example: 'My comment'
+                    archivename:
+                      type: string
+                      description: Name of the archive file, only for import
+                      example: '20240508072948_MyFile.png'
+                content_hash:
+                  type: string
+                  example: 'abc...cba'
+        metadata:
+          type: object
+          properties:
             domain_id:
               type: string
               example: 'abc123'
-            domain_snapshot_title:
+            time_stamp:
               type: string
-              example: 'Data Accounting:DomainSnapshot 1'
-            witness_hash:
+              example: '20240508072948'
+            previous_verification_hash:
               type: string
-              nullable: true
-              example: 'abc123'
-            domain_snapshot_genesis_hash:
+              example: 'abc...cba'
+            merge_hash:
               type: string
-              example: 'abc....cba'
-            merkle_root:
+              description: If revision was created by merging remote revisions, this shows the hash of the remote revision it was merged from
+              example: 'abc...cba'
+            metadata_hash:
               type: string
-              example: 'abc....cba'
-            witness_event_verification_hash:
+              example: 'abc...cba'
+            verification_hash:
               type: string
-              example: 'abc....cba'
-            witness_network:
+              example: 'abc...cba'
+        signature:
+          type: object
+          properties:
+            signature:
               type: string
-              example: 'goerli'
-            smart_contract_address:
+              example: '0xabc...cba'
+            public_key:
               type: string
-              example: '0xabc123'
-            witness_event_transaction_hash:
+              example: '0xabc...cba'
+            wallet_address:
               type: string
-              example: 'ABC'
-            sender_account_address:
+              example: '0xabc...cba'
+            signature_hash:
               type: string
-              example: 'ABC'
-            source:
-              type: string
-              nullable: true
-              example: 'abc'
-    ProofNode:
-        type: object
-        properties:
-          witness_event_verification_hash:
-            type: string
-            example: 'abc...cba'
-          depth:
-            type: integer
-            format: int64
-            example: 1
-          left_leaf:
-            type: string
-            example: 'abc...cba'
-          right_leaf:
-            type: string
-            example: 'abc...cba'
-          successor:
-            type: string
-            example: 'abc...cba'
-          id:
-            type: integer
-            format: int64
-            example: 1
-          witness_event_id:
-            type: integer
-            example: 1
-    ExportImportEntity:
-        type: object
-        properties:
-          verification_context:
-            type: object
-            properties:
-              has_previous_signature:
-                type: boolean
-                example: true
-              has_previous_witness:
-                type: boolean
-                example: true
-          content:
-            type: object
-            properties:
-              content:
-                type: object
-                properties:
-                  content:
-                    type: object
-                    properties:
-                      main:
-                        type: string
-                        description: Main content of the revision, text of the page
-                        example: 'Hello, world!'
-                      signature-slot:
-                        type: string
-                        description: JSON string of an array of signatures
-                        example: "[{\"signature\": \"0x..,\", \"timestamp\": \"20240101101010\"}...]"
-                      transclusion-hashes:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            dbkey:
-                              type: string
-                              example: 'MyPage'
-                            ns:
-                              type: integer
-                              example: 10
-                            verification_hash:
-                                type: string
-                                example: 'abc...cba'
-                    file:
-                      type: object
-                      properties:
-                        data:
-                          type: string
-                          description: Base64 encoded file data
-                          example: 'd3an...asd'
-                        filename:
-                          type: string
-                          example: 'MyFile.png'
-                        size:
-                          type: integer
-                          description: Size of the file in bytes
-                          example: 12345
-                        comment:
-                          type: string
-                          description: Comment added when uploading file
-                          example: 'My comment'
-                        archivename:
-                          type: string
-                          description: Name of the archive file, only for import
-                          example: '20240508072948_MyFile.png'
-                  content_hash:
-                    type: string
-                    example: 'abc...cba'
-          metadata:
-            type: object
-            properties:
-              domain_id:
-                type: string
-                example: 'abc123'
-              time_stamp:
-                type: string
-                example: '20240508072948'
-              previous_verification_hash:
-                type: string
-                example: 'abc...cba'
-              merge_hash:
-                type: string
-                description: If revision was created by merging remote revisions, this shows the hash of the remote revision it was merged from
-                example: 'abc...cba'                
-              metadata_hash:
-                type: string
-                example: 'abc...cba'
-              verification_hash:
-                type: string
-                example: 'abc...cba'
-          signature:
-            type: object
-            properties:
-              signature:
-                type: string
-                example: '0xabc...cba'
-              public_key:
-                type: string
-                example: '0xabc...cba'
-              wallet_address:
-                type: string
-                example: '0xabc...cba'
-              signature_hash:
-                type: string
-                example: 'abc...cba'
+              example: 'abc...cba'
     HashChainInfo:
-        type: object
-        properties:
-          genesis_hash:
-            type: string
-            example: 'abc...cba'
-          domain_id:
-            type: string
-            example: 'abc123'
-          title:
-            type: string
-            example: 'Main_Page'
-          namespace:
-            type: integer
-            example: 0
-          chain_height:
-            type: integer
-            example: 1
-          site_info:
-            $ref: '#/components/schemas/SiteInfo'
+      type: object
+      properties:
+        genesis_hash:
+          type: string
+          example: 'abc...cba'
+        domain_id:
+          type: string
+          example: 'abc123'
+        title:
+          type: string
+          example: 'Main_Page'
+        namespace:
+          type: integer
+          example: 0
+        chain_height:
+          type: integer
+          example: 1
+        site_info:
+          $ref: '#/components/schemas/SiteInfo'
     SiteInfo:
-        type: object
-        properties:
-          site_name:
-            type: string
-            example: 'PKC'
-          base:
-            type: string
-            example: 'https://url/index.php/Main_Page'
-          generator:
-            type: string
-            example: 'MediaWiki 1.36.0'
-          version:
-            type: string
-            example: '1'
+      type: object
+      properties:
+        site_name:
+          type: string
+          example: 'PKC'
+        base:
+          type: string
+          example: 'https://url/index.php/Main_Page'
+        generator:
+          type: string
+          example: 'MediaWiki 1.36.0'
+        version:
+          type: string
+          example: '1'
+    RecentChange:
+      type: object
+      properties:
+        title:
+          type: string
+          example: 'Main_Page'
+        revision:
+          type: integer
+          example: 1
+        hash:
+          type: string
+          example: 'abc...cba'
+        touched:
+          type: string
+          example: '20240508072948'

--- a/extension.json
+++ b/extension.json
@@ -351,6 +351,13 @@
 			"services": [
 				"PermissionManager", "DataAccountingRevisionManipulator", "TitleFactory", "RevisionLookup"
 			]
+		},
+		{
+			"path": "/data_accounting/recent_changes",
+			"class": "DataAccounting\\API\\RecentChangesHandler",
+			"services": [
+				"PermissionManager", "DBLoadBalancer", "TitleFactory"
+			]
 		}
 	],
 	"ResourceFileModulePaths": {

--- a/includes/API/RecentChangesHandler.php
+++ b/includes/API/RecentChangesHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace DataAccounting\API;
+
+use DateTime;
+use InvalidArgumentException;
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Rest\SimpleHandler;
+use TitleFactory;
+use Wikimedia\ParamValidator\ParamValidator;
+use Wikimedia\Rdbms\ILoadBalancer;
+
+class RecentChangesHandler extends SimpleHandler {
+
+	/** @var PermissionManager */
+	private $permissionManager;
+
+	/** @var ILoadBalancer */
+	private $loadBalancer;
+
+	/** @var TitleFactory */
+	private $titleFactory;
+
+	/**
+	 * @param PermissionManager $permissionManager
+	 * @param ILoadBalancer $loadBalancer
+	 * @param TitleFactory $titleFactory
+	 */
+	public function __construct(
+		PermissionManager $permissionManager, ILoadBalancer $loadBalancer, TitleFactory $titleFactory
+	) {
+		$this->permissionManager = $permissionManager;
+		$this->loadBalancer = $loadBalancer;
+		$this->titleFactory = $titleFactory;
+	}
+
+	/**
+	 * @return true
+	 */
+	public function needsReadAccess() {
+		return true;
+	}
+
+	/** @inheritDoc */
+	public function run() {
+		$db = $this->loadBalancer->getConnection( DB_REPLICA );
+		$params = $this->getValidatedParams();
+		$limit = $params['count'];
+		$since = $params['since'] ?? null;
+
+		$conds = [];
+		if ( $since ) {
+			$time = DateTime::createFromFormat( 'YmdHis', $since );
+			if ( !$time ) {
+				throw new InvalidArgumentException( 'Invalid value for "since" parameter' );
+			}
+			$conds[] = 'page_touched >= ' . $db->addQuotes( $time->format( 'YmdHis' ) );
+		}
+
+		$res = $db->select(
+			[ 'p' => 'page', 'rv' => 'revision_verification' ],
+			[
+				'p.page_id', 'p.page_title', 'p.page_namespace', 'p.page_latest',
+				'p.page_touched', 'rv.verification_hash'
+			],
+			$conds,
+			__METHOD__,
+			[ 'LIMIT' => $limit, 'ORDER BY' => 'rev_id DESC' ],
+			[
+				'rv' => [ 'INNER JOIN', 'page_latest = rev_id' ]
+			]
+		);
+
+		$changes = [];
+		foreach ( $res as $row ) {
+			$title = $this->titleFactory->newFromRow( $row );
+			if ( !$title->exists() ) {
+				// for sanity
+				continue;
+			}
+			$changes[] = [
+				'title' => $title->getPrefixedText(),
+				'revision' => (int)$row->page_latest,
+				'hash' => $row->verification_hash,
+				'touched' => $row->page_touched,
+			];
+		}
+
+		return $this->getResponseFactory()->createJson( $changes );
+	}
+
+	/** @inheritDoc */
+	public function getParamSettings() {
+		return [
+			'count' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+				ParamValidator::PARAM_DEFAULT => 500,
+			],
+			'since' => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false,
+			],
+		];
+	}
+}

--- a/includes/Transfer/Importer.php
+++ b/includes/Transfer/Importer.php
@@ -126,7 +126,7 @@
 		 }
 
 		 $this->revisionImporter->import( $revision );
-
+		 $this->updatePageTouched( $revision->getTitle() );
 		 $status = $this->newRevisionStatus( $revision );
 		 if ( $status->isOK() ) {
 			 $this->notifyRecentChange( $revision );
@@ -529,4 +529,22 @@
 			 )->parse()
 		 ] );
 	 }
+
+	 /**
+	  * @param Title|null $title
+	  * @return void
+	  */
+	 private function updatePageTouched( ?Title $title ) {
+		 if ( !$title ) {
+			 return;
+		 }
+		 $db = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
+		 $db->update(
+			 'page',
+			 [ 'page_touched' => $db->timestamp( MWTimestamp::now( TS_MW ) ) ],
+			 [ 'page_id' => $title->getArticleID() ],
+			 __METHOD__
+		 );
+	 }
+
  }


### PR DESCRIPTION
Normal API is updated deferred and also doesnt work well for Imported pages

https://github.com/inblockio/mediawiki-extensions-Aqua/issues/401

Issue: normal recent changes endpoint does return imported pages, buut, those revisions will have timestamp or the original revision, ie. not the timestamp of import, but of original creation. We cannot change this, as timestamp is included in hash. Also, it is update on deferred updates, so page will take some time to appear on RC after change.

Use the new API that is specifically done for your use-case. Its updated immediately and will show time of the import as the "last change" timestamp (without affecting original revision timestamp)

See updated API docu for more info: /data_accounting/recent_changes